### PR TITLE
fix: bug if layer dim is 1

### DIFF
--- a/micrograd.py
+++ b/micrograd.py
@@ -186,6 +186,8 @@ class MLP(Module):
     def __call__(self, x):
         for layer in self.layers:
             x = layer(x)
+            if not isinstance(x, list):
+                x = [x]
         return x
 
     def parameters(self):

--- a/micrograd.py
+++ b/micrograd.py
@@ -169,7 +169,7 @@ class Layer(Module):
 
     def __call__(self, x):
         out = [n(x) for n in self.neurons]
-        return out[0] if len(out) == 1 else out
+        return out
 
     def parameters(self):
         return [p for n in self.neurons for p in n.parameters()]
@@ -186,8 +186,6 @@ class MLP(Module):
     def __call__(self, x):
         for layer in self.layers:
             x = layer(x)
-            if not isinstance(x, list):
-                x = [x]
         return x
 
     def parameters(self):


### PR DESCRIPTION
to reproduce the bug, change any output dim to 1 in the MLP initialization:
e.g.
`model = MLP(2, [1, 3])`
`model = MLP(2, [3, 1, 3])`